### PR TITLE
Improved performance for 3D demo.

### DIFF
--- a/demo3d.html
+++ b/demo3d.html
@@ -41,15 +41,18 @@ var image = ctx.createImageData(canvas.width, canvas.height);
 var data = image.data;
 
 var height = 0;
-setInterval(function() {
+function drawFrame() {
   var start = Date.now();
+  // Cache width and height values for the canvas.
+  var cWidth = canvas.width;
+  var cHeight = canvas.height;
 
-  for (var x = 0; x < canvas.width; x++) {
-    for (var y = 0; y < canvas.height; y++) {
+  for (var x = 0; x < cWidth; x++) {
+    for (var y = 0; y < cHeight; y++) {
       var value = Math.abs(noise.simplex3(x / 100, y / 100, height));
       value *= 256;
 
-      var cell = (x + y * canvas.width) * 4;
+      var cell = (x + y * cWidth) * 4;
       data[cell] = data[cell + 1] = data[cell + 2] = value;
       data[cell] += Math.max(0, (25 - value) * 8);
       data[cell + 3] = 255; // alpha.
@@ -64,12 +67,16 @@ setInterval(function() {
 
   ctx.font = '16px sans-serif'
   ctx.textAlign = 'center';
-  ctx.fillText('Rendered in ' + (end - start) + ' ms', canvas.width / 2, canvas.height - 20);
+  ctx.fillText('Rendered in ' + (end - start) + ' ms', cWidth / 2, cHeight - 20);
 
   if(console) {
     console.log('Rendered in ' + (end - start) + ' ms');
   }
 
   height += 0.05;
-}, 1000/30);
+  requestAnimationFrame(drawFrame);
+}
+
+requestAnimationFrame(drawFrame);
+
 </script>


### PR DESCRIPTION
Added caching of canvas .width and .height return values.  These
calls were taking up a large amount of overall execution time on my
machine and caching them dropped the time to render a frame from
110ms to 60ms on my machine.

requestAnimation() replaces setInterval.  This lets the browser
decide when to draw the frame, resulting in a smoother frame rate.
